### PR TITLE
Improve reverse scheme validation and add utility tests

### DIFF
--- a/core/proxy/server.go
+++ b/core/proxy/server.go
@@ -125,7 +125,7 @@ func HandleConnection(conn net.Conn, forwardURL string, auth *utils.Auth, scheme
 		}
 	}
 
-	// 如果不是 socks5 / ssh / tls / https 默认使用 HTTP
+	// 如果不是 socks5 / ssh / tls / https 默认使用 HTTP/1.1
 	HandleHTTP1(newBufferedConn(conn, br), forwardURL, auth, nil)
 }
 

--- a/core/reverse/client.go
+++ b/core/reverse/client.go
@@ -25,7 +25,7 @@ var (
 )
 
 func StartClient(listenURL string, forwardURL string) {
-	// 打删协议前缀
+	// 去掉协议前缀
 	if strings.HasPrefix(listenURL, "tcp://") {
 		listenURL = strings.TrimPrefix(listenURL, "tcp://")
 	} else if strings.HasPrefix(listenURL, "udp://") {

--- a/core/reverse/server.go
+++ b/core/reverse/server.go
@@ -42,13 +42,7 @@ func StartServer(listenURL string) {
 		}
 	}
 
-	s := strings.ToLower(scheme)
-	proxySchemes := map[string]struct{}{
-		"tls:":  {},
-		"ssh:":  {},
-		"quic:": {},
-	}
-	if _, exists := proxySchemes[s]; exists {
+	if !isSupportedReverseScheme(scheme) {
 		utils.Info("Reverse Server only supports proxy protocols (tls, ssh, quic). Given: %s", scheme)
 		return
 	}
@@ -436,4 +430,13 @@ func generateSessionID() string {
 	b := make([]byte, 8)
 	rand.Read(b)
 	return fmt.Sprintf("%x", b)
+}
+
+func isSupportedReverseScheme(scheme string) bool {
+	switch strings.ToLower(scheme) {
+	case "tls", "ssh", "quic":
+		return true
+	default:
+		return false
+	}
 }

--- a/core/reverse/server_test.go
+++ b/core/reverse/server_test.go
@@ -1,0 +1,26 @@
+package reverse
+
+import "testing"
+
+func TestIsSupportedReverseScheme(t *testing.T) {
+	testCases := []struct {
+		name   string
+		scheme string
+		want   bool
+	}{
+		{name: "tls", scheme: "tls", want: true},
+		{name: "ssh", scheme: "ssh", want: true},
+		{name: "quic", scheme: "quic", want: true},
+		{name: "upper case", scheme: "TLS", want: true},
+		{name: "unsupported http", scheme: "http", want: false},
+		{name: "empty", scheme: "", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSupportedReverseScheme(tc.scheme); got != tc.want {
+				t.Fatalf("isSupportedReverseScheme(%q) = %v, want %v", tc.scheme, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/utils/tools_test.go
+++ b/core/utils/tools_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import "testing"
+
+func TestFixURLScheme(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "http2 converted to https", in: "http2://example.com", want: "https://example.com"},
+		{name: "unchanged https", in: "https://example.com", want: "https://example.com"},
+		{name: "unchanged other scheme", in: "socks5://127.0.0.1:1080", want: "socks5://127.0.0.1:1080"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FixURLScheme(tc.in); got != tc.want {
+				t.Fatalf("FixURLScheme(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- enforce reverse server scheme validation and clarify proxy fallback comments
- fix a reverse client comment typo for readability
- add unit coverage for reverse scheme support and FixURLScheme normalization

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694eb3b1e2908320a05a4ed0c6ba8b4e)